### PR TITLE
Fixed #16 added the possibility to get a couuntry's flag in the form of an emoji

### DIFF
--- a/src/CountryData.Standard/CountryHelper.cs
+++ b/src/CountryData.Standard/CountryHelper.cs
@@ -10,12 +10,12 @@ namespace CountryData.Standard
     {
         private readonly IEnumerable<Country> _Countries;
         private const string strFileName = "CountryData.Standard.data.json";
+
         public CountryHelper()
          {          
             var json = GetJsonData(strFileName);
             _Countries = JsonConvert.DeserializeObject<List<Country>>(json);
         }
-
 
         private string GetJsonData(string path)
         {
@@ -51,6 +51,15 @@ namespace CountryData.Standard
             return _Countries.SingleOrDefault(c => c.CountryShortCode == shortCode);
         }
 
+        /// <summary>
+        /// Gets the flag of the country, in the form of an emoji.
+        /// </summary>
+        /// <param name="country"></param>
+        /// <returns></returns>
+        public string GetCountryEmojiFlag(string shortCode)
+        {
+            return string.Concat(shortCode.ToUpper().Select(x => char.ConvertFromUtf32(x + 0x1F1A5)));
+        }
 
          /// <summary>
         /// Selects Regions in a Particular Country

--- a/test/CountryData.UnitTests/CountryHelperTests.cs
+++ b/test/CountryData.UnitTests/CountryHelperTests.cs
@@ -1,4 +1,4 @@
-using CountryData.Standard;
+﻿using CountryData.Standard;
 using FluentAssertions;
 using System.Collections.Generic;
 using Xunit;
@@ -32,6 +32,25 @@ public class CountryHelperTests
         //Assert
         country.Should().NotBeNull();
         country.CountryShortCode.Should().Be(shortCode);
+    }
+
+    [Theory]
+    [InlineData("GH")]
+    [InlineData("CM")]
+    [InlineData("US")]
+    public void GetCountryFlagByCode_WithCorrectCode_ShouldReturnEmojiFlag(string shortCode) 
+    {
+        //Act
+        var countryFlag = _countryHelper.GetCountryEmojiFlag(shortCode);
+
+        //Assert
+        countryFlag.Should().NotBeNull();
+        if (shortCode == "GH")
+            countryFlag.Should().Be("🇬🇭");
+        else if (shortCode == "CM")
+            countryFlag.Should().Be("🇨🇲");
+        else if (shortCode == "US")
+            countryFlag.Should().Be("🇺🇸");
     }
 
     [Theory]


### PR DESCRIPTION
Made it possible to get a country's flag from its country code in the form of an emoji.
This emoji could be displayed almost everywhere since emoji alphanumeric characters are recognized universally. 