### PR TITLE
French regions

### DIFF
--- a/src/CountryData.Standard/data.json
+++ b/src/CountryData.Standard/data.json
@@ -4716,7 +4716,7 @@
                 "shortCode": "PDL"
             },
             {
-                "name": "Provence-Alpes-Cote d'Azur",
+                "name": "Provence-Alpes-Côte d'Azur",
                 "shortCode": "PAC"
             },
             {
@@ -4740,7 +4740,7 @@
                 "shortCode": "YT"
             },
             {
-                "name": "Novelle-Calédonie",
+                "name": "Nouvelle Calédonie",
                 "shortCode": "NC"
             },
             {


### PR DESCRIPTION
Typos in `Provence-Alpes-Côte d'Azur` and `Nouvelle Calédonie`.