### PR TITLE
Update CountryData.Standard to v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@
 ### Install Library
 ##### Package Manager
 ```cSharp
-   PM> Install-Package CountryData.Standard -Version 1.4.1
+   PM> Install-Package CountryData.Standard -Version 1.5.0
 ```
 
 ##### .NET CLI
 ```cSharp
-   > dotnet add package CountryData.Standard --version 1.4.1
+   > dotnet add package CountryData.Standard --version 1.5.0
 ```
 
 

--- a/src/CountryData.Standard/CountryData.Standard.csproj
+++ b/src/CountryData.Standard/CountryData.Standard.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/frankodoom/CountryData.Standard</RepositoryUrl>
     <PackageTags>Xamarin, Country-Api Country-Data Country-Region</PackageTags>
     <NeutralLanguage />
-    <Version>1.4.1</Version>
+    <Version>1.5.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <ReleaseNotes>Added new functionality to get country phone codes</ReleaseNotes>


### PR DESCRIPTION
Updated README.md to reflect the new version 1.5.0 for the CountryData.Standard package in both the Package Manager and .NET CLI installation instructions. Updated CountryData.Standard.csproj to change the version from 1.4.1 to 1.5.0. Added release notes indicating new functionality to get country phone codes.